### PR TITLE
Draft: allow to run a deployment without threads

### DIFF
--- a/src/lib/common/mutex.cpp
+++ b/src/lib/common/mutex.cpp
@@ -1,3 +1,13 @@
 // Copyright © 2021 Giorgio Audrito. All Rights Reserved.
 
 #include "lib/common/mutex.hpp"
+
+#ifdef FCPP_DISABLE_THREADS
+//! @cond INTERNAL
+namespace std {
+    namespace this_thread {
+        void yield() {}
+    };
+}
+//! @endcond
+#endif

--- a/src/lib/common/mutex.hpp
+++ b/src/lib/common/mutex.hpp
@@ -32,7 +32,7 @@ namespace std {
     constexpr try_to_lock_t try_to_lock{};
 
     namespace this_thread {
-        void yield() {}
+        void yield();
         template <typename C, typename D>
         void sleep_until(chrono::time_point<C,D> const&) {}
         template <typename R, typename P>

--- a/src/lib/deployment/hardware_connector.hpp
+++ b/src/lib/deployment/hardware_connector.hpp
@@ -233,6 +233,9 @@ struct hardware_connector {
             //! @brief Sizes of messages received from neighbours.
             field<size_t> m_nbr_msg_size;
 
+        #ifdef FCPP_DISABLE_THREADS
+          public:
+        #endif
             //! @brief Backend regulating and performing the connection.
             connector_type m_network;
         };


### PR DESCRIPTION
This commit makes the run method try to execute only one round.
The time for the next round will be saved in the field `sleep_until_t`.
A single message receive and send operation can be run by calling `node_at(fcpp::os::uid(), lock).m_network.manage()` on the net object.