### PR TITLE
blist_idem_collection method related update

### DIFF
--- a/src/lib/coordination/collection.hpp
+++ b/src/lib/coordination/collection.hpp
@@ -122,16 +122,17 @@ template <typename T> using wmp_collection_t = common::export_list<T,field<real_
 
 //! @brief Collects distributed data with a bounded-loss information-speed-threshold strategy and a idempotent accumulate function.
 template <typename node_t, typename T, typename G, typename = common::if_signature<G, T(T,T)>>
-T blist_idem_collection(node_t& node, trace_t call_point, real_t const& distance, T const& value, real_t radius, real_t speed, T const& null, G&& accumulate) {
+T blist_idem_collection(node_t& node, trace_t call_point, real_t const& distance, T const& value, real_t radius, real_t speed, T const& null, real_t epsilon, G&& accumulate) {
     internal::trace_call trace_caller(node.stack_trace, call_point);
 
     field<real_t> nbrdist = nbr(node, 0, distance);
     real_t t = node.current_time();
-    field<real_t> Tu = nbr(node, 1, node.next_time());
+    field<real_t> Tu = nbr(node, 1, node.next_time() + epsilon);
     field<real_t> Pu = nbr(node, 2, distance + speed * (node.next_time() - t));
     field<real_t> maxDistNow = node.nbr_dist() + speed * node.nbr_lag();
     field<real_t> Vwst = mux(isfinite(distance) and maxDistNow < radius, (distance - Pu) / (Tu - t), (real_t)(-INF));
-    field<real_t> nbrThreshold = nbr(node, 4, max_hood(node, 0, Vwst, -INF));
+    field<real_t> nbrThreshold = nbr(node, 4, max_hood(node, 0, Vwst, 0));
+
     return nbr(node, 3, value, [&](field<T> old){
         field<T> nv = mux(isfinite(distance) and nbrdist >= distance + node.nbr_lag() * nbrThreshold, old, null);
         return fold_hood(node, 0, accumulate, nv, value);

--- a/src/lib/coordination/collection.hpp
+++ b/src/lib/coordination/collection.hpp
@@ -120,6 +120,38 @@ T wmp_collection(node_t& node, trace_t call_point, real_t distance, real_t radiu
 template <typename T> using wmp_collection_t = common::export_list<T,field<real_t>,real_t>;
 
 
+//! @brief Collects distributed data with a Lossless-information-speed-threshold strategy (blist) and a idempotent accumulate function.
+template <typename node_t, typename T, typename G, typename = common::if_signature<G, T(T,T)>>
+T blist_idem_collection(node_t& node, trace_t call_point, real_t const& distance, T const& value, real_t radius, real_t speed, T const& null, G&& accumulate) {
+    internal::trace_call trace_caller(node.stack_trace, call_point);
+
+    field<real_t> nbrdist = nbr(node,0, distance);
+    real_t t = node.current_time();
+
+    field<real_t> Tu = nbr(node,1, node.next_time());
+    field<real_t> Pu = nbr(node,0,distance + speed * (Tu - t));
+
+    field<real_t> dist = node.nbr_dist();
+
+    field<real_t> maxDistanceNow = dist + speed * node.nbr_lag();
+
+    field<real_t> Vwst = mux(isfinite(distance) && distance > nbrdist, (distance - Pu) / (Tu - t) , field<real_t>{0} ) ;
+
+    field<real_t> threshold = mux( (isfinite(distance) && maxDistanceNow < radius), max_hood(node,0, Vwst) , -INF);
+
+    return nbr(node,1, value, [&](field<T> old){
+        return fold_hood(node,0, accumulate, mux(nbrdist >= distance + node.nbr_lag() * nbr(node,1,threshold) &&
+                                                    nbrdist > distance, old, null), value);
+    });
+
+}
+
+//! @brief Export list for blist_idem_collection.
+template <typename T> using blist_idem_collection_t = common::export_list<T,field<real_t>,real_t >;
+
+
+
+
 }
 
 

--- a/src/lib/coordination/utils.hpp
+++ b/src/lib/coordination/utils.hpp
@@ -287,7 +287,7 @@ inline to_local<A> max_hood(node_t& node, trace_t call_point, A const& a) {
     }, a);
 }
 
-//! @brief Reduces a field to a single value by maximum with a default value for self.
+//! @brief Reduces a field to a single value by maximum with a given value for self.
 template <typename node_t, typename A, typename B>
 inline to_local<A> max_hood(node_t& node, trace_t call_point, A const& a, B const& b) {
     return fold_hood(node, call_point, [] (to_local<A> const& x, to_local<A> const& y) -> to_local<A> {

--- a/src/test/coordination/collection.cpp
+++ b/src/test/coordination/collection.cpp
@@ -194,26 +194,30 @@ MULTI_TEST(CollectionTest, BLISTidem, O, 3) {
     test_net<combo<O>, std::tuple<real_t>(int, int)> n{
         [&](auto& node, int id, int val){
             return std::make_tuple(
-                coordination::blist_idem_collection(node, 0, id, val, 2, 0, 0, [&](int x, int y){return std::max(x,y);})
+                coordination::blist_idem_collection(node, 0, id, val, 2, 0, 0, 1,[&](int x, int y){return std::max(x,y);})
             );
         }
-    };  
-//    EXPECT_ROUND(n, {0, 1, 2},
-//                    {1, 2, 4},
-//                    {1, 2, 4});
-//    EXPECT_ROUND(n, {0, 1, 2},
-//                    {1, 2, 4},
-//                    {2, 4, 4});
-//    EXPECT_ROUND(n, {0, 1, 2},
-//                    {1, 2, 4},
-//                    {4, 4, 4});
-//    EXPECT_ROUND(n, {0, 1, 2},
-//                    {1, 2, 5},
-//                    {4, 4, 5});
-//    EXPECT_ROUND(n, {0, 1, 2},
-//                    {1, 2, 5},
-//                    {4, 5, 5});
-//    EXPECT_ROUND(n, {0, 1, 2},
-//                    {1, 2, 5},
-//                    {5, 5, 5});
+    };
+    EXPECT_ROUND(n, {0, 1, 2},
+                    {1, 2, 4},
+                    {1, 2, 4});
+    EXPECT_ROUND(n, {0, 1, 2},
+                    {1, 2, 4},
+                    {2, 4, 4});
+    EXPECT_ROUND(n, {0, 1, 2},
+                    {1, 2, 4},
+                    {4, 4, 4});
+    EXPECT_ROUND(n, {0, 1, 2},
+                    {1, 2, 4},
+                    {4, 4, 4});
+
+    EXPECT_ROUND(n, {0, 1, 2},
+                    {1, 2, 2},
+                    {4, 4, 2});
+    EXPECT_ROUND(n, {0, 1, 2},
+                    {1, 2, 2},
+                    {4, 2, 2});
+    EXPECT_ROUND(n, {0, 1, 2},
+                    {1, 2, 2},
+                    {2, 2, 2}); 
 }


### PR DESCRIPTION
- blist_idem_collection fixes:
    1) added epsilon parameter, used in time upper-bound for next scheduled event. 
    2) set threshold to have non-negative values.

- added tests for blist_idem_collection method

- fix in comment description of max_hood method