### PR TITLE
Fix process hash mismatch between 32-bit and 64-bit nodes

### DIFF
--- a/src/lib/common/serialize.hpp
+++ b/src/lib/common/serialize.hpp
@@ -395,9 +395,10 @@ namespace details {
         return s;
     }
 
+    //! @brief Hash iterable size as uint64_t so 32-bit and 64-bit nodes agree.
     template <typename T, typename S>
     hstream& iterable_serialize(hstream& s, T& x, S, wrapper<void> = {}) {
-        s.write(x.size());
+        s.write(static_cast<uint64_t>(x.size()));
         for (auto& i : x) s & i;
         return s;
     }

--- a/src/lib/common/serialize.hpp
+++ b/src/lib/common/serialize.hpp
@@ -395,7 +395,6 @@ namespace details {
         return s;
     }
 
-    //! @brief Hash iterable size as uint64_t so 32-bit and 64-bit nodes agree.
     template <typename T, typename S>
     hstream& iterable_serialize(hstream& s, T& x, S, wrapper<void> = {}) {
         s.write(static_cast<uint64_t>(x.size()));


### PR DESCRIPTION
## Summary
- Hash iterable container sizes as `uint64_t` in `hstream` serialization so process/spawn indices agree across 32-bit and 64-bit architectures.
- Previously `s.write(x.size())` embedded native `sizeof(size_t)` (4 vs 8 bytes), so mixed deployments (e.g. 64-bit kiosk + 32-bit robot) hashed the same keys differently and never observed each other inside a process.

## Scope note
This PR contains **only the hash fix** in `serialize.hpp`.

It intentionally **does not** include the RX reject / residual hex logging that lived in `hardware_connector.hpp` on the Luckfox fork ([`robonextgen/fcpp-luckfox`](https://github.com/robonextgen/fcpp-luckfox), commit `ded85b9`). That diagnostic logging is what helped surface the 32/64-bit hash mismatch in the field; it is kept out of upstream as debug-only noise.